### PR TITLE
Include user-select vendor prefixes in demo

### DIFF
--- a/gs/styles.css
+++ b/gs/styles.css
@@ -6,6 +6,8 @@
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+    -moz-user-select: none;
+    -webkit-user-select: none;
     user-select: none;
 }
 


### PR DESCRIPTION
Latest Firefox and latest Safari still only support the prefixed versions of the `user-select` CSS property. Reference: https://caniuse.com/#search=user-select (see top-right corner yellow boxes indicating prefixed version of property).