### PR TITLE
Allow text selection in demo for code sample, but avoid text selection flashing while using demo

### DIFF
--- a/gs/code.js
+++ b/gs/code.js
@@ -2,12 +2,16 @@ const options = {
 
     // Class for the selection-area
     class: 'selection',
-    
+
     // All elements in this container can be selected
     containers: ['.box-wrap'],
 
     // The container is also the boundary in this case
     boundarys: ['.box-wrap'],
+
+    onStart(evt) {
+        document.body.classList.add('selecting');
+    },
 
     onMove(evt) {
 
@@ -21,7 +25,7 @@ const options = {
             se.classList.add('selected');
         }
 
-        // Remove the class from elements which where removed 
+        // Remove the class from elements which where removed
         // since the last selection.
         for (let rm of removedElements) {
             rm.classList.remove('selected');
@@ -34,6 +38,10 @@ const options = {
         for (let rm of evt.selectedElements) {
             rm.classList.remove('selected');
         }
+
+        // Clear text selection
+        (window.getSelection || document.getSelection)().removeAllRanges();
+        document.body.classList.remove('selecting');
     },
 };
 

--- a/gs/code.js
+++ b/gs/code.js
@@ -9,7 +9,8 @@ const options = {
     // The container is also the boundary in this case
     boundarys: ['.box-wrap'],
 
-    onStart(evt) {
+    onStart() {
+        // Applies 'user-select: none' to all elements on the page via a stylesheet
         document.body.classList.add('selecting');
     },
 

--- a/gs/styles.css
+++ b/gs/styles.css
@@ -101,6 +101,12 @@ main .boxes.blue div.selected {
   border: 0.05em solid rgba(0, 0, 255, 0.2);
 }
 
+body.selecting,
+body.selecting * {
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+}
 
 main section.demo-code pre {
   background: #F4F1EF;

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 </head>
 
 <body>
-  
+
   <a href="https://github.com/Simonwep/selection" target="_blank">
     <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub!">
   </a>
@@ -134,12 +134,17 @@
 
     // Class for the selection-area
     class: 'selection',
-    
+
     // All elements in this container can be selected
     containers: ['.box-wrap'],
 
     // The container is also the boundary in this case
     boundarys: ['.box-wrap'],
+
+    onStart() {
+        // Applies 'user-select: none' to all elements on the page via a stylesheet
+        document.body.classList.add('selecting');
+    },
 
     onMove(evt) {
 
@@ -153,7 +158,7 @@
             se.classList.add('selected');
         }
 
-        // Remove the class from elements which where removed 
+        // Remove the class from elements which where removed
         // since the last selection.
         for (let rm of removedElements) {
             rm.classList.remove('selected');
@@ -166,6 +171,10 @@
         for (let rm of evt.selectedElements) {
             rm.classList.remove('selected');
         }
+
+        // Clear text selection
+        (window.getSelection || document.getSelection)().removeAllRanges();
+        document.body.classList.remove('selecting');
     },
 };
 


### PR DESCRIPTION
I realize the demo is a WIP, but I also realized I could make a nicer solution for the text selection problem. It applies a `selecting` class the body `onStart`, which applies (vendor-prefixed) `user-select: none` styles, and removes that class `onStop`, also clearing all text selections that might’ve occurred while the user was dragging around the page (`getSelection().removeAllRanges()`).

Note that I didn’t update the code sample in the demo with those changes, because they also requiressome custom CSS, but I’d be happy to do so if that would be desirable. I could just put a comment in `onStart`:
```js
    onStart(evt) {
        // Applies 'user-select: none' to all elements on the page via a stylesheet
        document.body.classList.add('selecting');
    },
```

**UPDATE** I pushed up a commit that adds that comment that I proposed and updates the example section in the demo HTML.