### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Use the `on(event, cb)` and `off(event, cb)` functions to bind / unbind event-li
 | Event      | Description
 | -------------- | ----------- | 
 | `beforestart`  | The `mousedown` / `touchstart` got called inside a valid boundary.  |
-| `start`        | User stardet the selection, the `startThreshold` got fulfilled. | 
+| `start`        | User started the selection, the `startThreshold` got fulfilled. | 
 | `move`         | The user dragged the mouse aroun. |
 | `stop`         | The user stopped the selection, called on `mouseup` and `touchend` / `touchcancel` after a selection. |
 


### PR DESCRIPTION
Line 112: 'stardet' => 'started'