### PR TITLE
Allow id prop to get passed to the React SelectionArea component 

### DIFF
--- a/packages/react/src/SelectionArea.tsx
+++ b/packages/react/src/SelectionArea.tsx
@@ -4,6 +4,7 @@ import {SelectionEvents, SelectionOptions} from '@vanilla/types';
 import React, {createRef, useEffect} from 'react';
 
 export interface SelectionAreaProps extends Omit<Partial<SelectionOptions>, 'boundaries'>, React.HTMLAttributes<HTMLDivElement> {
+    id?: string;
     className?: string;
     onBeforeStart?: SelectionEvents['beforestart'];
     onStart?: SelectionEvents['start'];
@@ -32,7 +33,7 @@ export const SelectionArea: React.FunctionComponent<SelectionAreaProps> = props 
     }, []);
 
     return (
-        <div ref={root} className={props.className}>
+        <div ref={root} className={props.className} id={props.id} >
             {props.children}
         </div>
     );


### PR DESCRIPTION
Thanks for building this package. It's been amazing to work with!

I'm working on an application where I'm grabbing the `id` of various components fairly frequently using event listeners. The rest of the architecture is already set up to look at ids so I thought it would be nice to allow the SelectionArea to receive `id` as one of its props. 