### PR TITLE
Add option to select which MouseButtons should trigger selection-start

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "3.4.0",
+  "version": "3.4.1",
   "npmClient": "pnpm"
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "dev": "pnpm run --parallel dev",
         "build": "pnpm run --recursive build",
-        "lint": "eslint 'packages/*/{src,demo}/*.{ts,tsx,vue,js}'",
+        "lint": "eslint \"packages/*/{src,demo}/*.{ts,tsx,vue,js}\"",
         "lint:fix": "pnpm run lint --fix",
         "test:ci": "pnpm run lint:fix && pnpm run build",
         "release:major": "lerna version major",

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@viselect/preact",
-    "version": "3.4.0",
+    "version": "3.4.1",
     "description": "Preact wrapper around the viselect vanilla library",
     "author": "Simon Reinisch <contact@reinisch.io>",
     "bugs": "https://github.com/Simonwep/selection/issues",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@viselect/react",
-    "version": "3.4.0",
+    "version": "3.4.1",
     "description": "React wrapper around the viselect vanilla library",
     "author": "Simon Reinisch <contact@reinisch.io>",
     "bugs": "https://github.com/Simonwep/selection/issues",

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@viselect/vanilla",
-    "version": "3.4.0",
+    "version": "3.4.1",
     "description": "Simple, lightweight and modern library library for making visual DOM Selections.",
     "author": "Simon Reinisch <contact@reinisch.io>",
     "bugs": "https://github.com/Simonwep/selection/issues",

--- a/packages/vanilla/src/index.ts
+++ b/packages/vanilla/src/index.ts
@@ -1,13 +1,32 @@
-import {EventTarget} from './EventEmitter';
-import type {AreaLocation, Coordinates, ScrollEvent, SelectionEvents, SelectionOptions, SelectionStore} from './types';
-import {PartialSelectionOptions} from './types';
-import {css, frames, Frames, intersects, isSafariBrowser, isTouchDevice, off, on, selectAll, SelectAllSelectors, simplifyEvent} from './utils';
+import { EventTarget } from './EventEmitter';
+import type {
+    AreaLocation,
+    Coordinates, MouseButton,
+    ScrollEvent,
+    SelectionEvents,
+    SelectionOptions,
+    SelectionStore
+} from './types';
+import { PartialSelectionOptions } from './types';
+import {
+    css,
+    frames,
+    Frames,
+    intersects,
+    isSafariBrowser,
+    isTouchDevice,
+    off,
+    on,
+    selectAll,
+    SelectAllSelectors,
+    simplifyEvent
+} from './utils';
 
 // Re-export types
 export * from './types';
 
 // Some var shorting for better compression and readability
-const {abs, max, min, ceil} = Math;
+const { abs, max, min, ceil } = Math;
 
 export default class SelectionArea extends EventTarget<SelectionEvents> {
     public static version = VERSION;
@@ -40,7 +59,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     private readonly _areaRect = new DOMRect();
 
     // Dynamically constructed area rect
-    private _areaLocation: AreaLocation = {y1: 0, x2: 0, y2: 0, x1: 0};
+    private _areaLocation: AreaLocation = { y1: 0, x2: 0, y2: 0, x1: 0 };
 
     // If a single click is being performed.
     // It's a single-click until the user dragged the mouse.
@@ -50,8 +69,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     // Is getting set on movement.
     private _scrollAvailable = true;
     private _scrollingActive = false;
-    private _scrollSpeed: Coordinates = {x: 0, y: 0};
-    private _scrollDelta: Coordinates = {x: 0, y: 0};
+    private _scrollSpeed: Coordinates = { x: 0, y: 0 };
+    private _scrollDelta: Coordinates = { x: 0, y: 0 };
 
     constructor(opt: PartialSelectionOptions) {
         super();
@@ -69,11 +88,12 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             behaviour: {
                 overlap: 'invert',
                 intersect: 'touch',
+                ignoredButtons: [],
                 ...opt.behaviour,
                 startThreshold: opt.behaviour?.startThreshold ?
                     typeof opt.behaviour.startThreshold === 'number' ?
                         opt.behaviour.startThreshold :
-                        {x: 10, y: 10, ...opt.behaviour.startThreshold} : {x: 10, y: 10},
+                        { x: 10, y: 10, ...opt.behaviour.startThreshold } : { x: 10, y: 10 },
                 scrolling: {
                     speedDivider: 10,
                     manualSpeed: 750,
@@ -106,7 +126,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             }
         }
 
-        const {document, selectionAreaClass, selectionContainerClass} = this._options;
+        const { document, selectionAreaClass, selectionContainerClass } = this._options;
         this._area = document.createElement('div');
         this._clippingElement = document.createElement('div');
         this._clippingElement.appendChild(this._area);
@@ -140,7 +160,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _bindStartEvents(activate = true): void {
-        const {document, features} = this._options;
+        const { document, features } = this._options;
         const fn = activate ? on : off;
 
         fn(document, 'mousedown', this._onTapStart);
@@ -150,9 +170,15 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _onTapStart(evt: MouseEvent | TouchEvent, silent = false): void {
-        const {x, y, target} = simplifyEvent(evt);
-        const {_options} = this;
-        const {document} = this._options;
+        // Check whether the starting button is in the ignored list
+        if ((evt instanceof MouseEvent) &&
+            this._options.behaviour.ignoredButtons.includes(evt.button as MouseButton)) {
+            return;
+        }
+
+        const { x, y, target } = simplifyEvent(evt);
+        const { _options } = this;
+        const { document } = this._options;
         const targetBoundingClientRect = target.getBoundingClientRect();
 
         // Find start-areas and boundaries
@@ -176,23 +202,23 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             return;
         }
 
-        this._areaLocation = {x1: x, y1: y, x2: 0, y2: 0};
+        this._areaLocation = { x1: x, y1: y, x2: 0, y2: 0 };
 
         // Lock scrolling in target container
         const scrollElement = document.scrollingElement ?? document.body;
-        this._scrollDelta = {x: scrollElement.scrollLeft, y: scrollElement.scrollTop};
+        this._scrollDelta = { x: scrollElement.scrollLeft, y: scrollElement.scrollTop };
 
         // To detect single-click
         this._singleClick = true;
         this.clearSelection(false, true);
 
-        on(document, ['touchmove', 'mousemove'], this._delayedTapMove, {passive: false});
+        on(document, ['touchmove', 'mousemove'], this._delayedTapMove, { passive: false });
         on(document, ['mouseup', 'touchcancel', 'touchend'], this._onTapStop);
         on(document, 'scroll', this._onScroll);
     }
 
     _onSingleTap(evt: MouseEvent | TouchEvent): void {
-        const {singleTap: {intersect}, range} = this._options.features;
+        const { singleTap: { intersect }, range } = this._options.features;
         const e = simplifyEvent(evt);
         let target;
 
@@ -201,9 +227,9 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         } else if (intersect === 'touch') {
             this.resolveSelectables();
 
-            const {x, y} = e;
+            const { x, y } = e;
             target = this._selectables.find(v => {
-                const {right, left, top, bottom} = v.getBoundingClientRect();
+                const { right, left, top, bottom } = v.getBoundingClientRect();
                 return x < right && x > left && y < bottom && y > top;
             });
         }
@@ -230,7 +256,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         }
 
         // Grab current store first in case it gets set back
-        const {stored} = this._selection;
+        const { stored } = this._selection;
         this._emitEvent('start', evt);
 
         if (evt.shiftKey && range && this._latestElement) {
@@ -263,9 +289,9 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _delayedTapMove(evt: MouseEvent | TouchEvent): void {
-        const {container, document, behaviour: {startThreshold}} = this._options;
-        const {x1, y1} = this._areaLocation; // Coordinates of first "tap"
-        const {x, y} = simplifyEvent(evt);
+        const { container, document, behaviour: { startThreshold } } = this._options;
+        const { x1, y1 } = this._areaLocation; // Coordinates of first "tap"
+        const { x, y } = simplifyEvent(evt);
 
         // Check pixel threshold
         if (
@@ -276,14 +302,14 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             // Different x and y threshold
             (typeof startThreshold === 'object' && abs(x - x1) >= (startThreshold as Coordinates).x || abs(y - y1) >= (startThreshold as Coordinates).y)
         ) {
-            off(document, ['mousemove', 'touchmove'], this._delayedTapMove, {passive: false});
+            off(document, ['mousemove', 'touchmove'], this._delayedTapMove, { passive: false });
 
             if (this._emitEvent('beforedrag', evt) === false) {
                 off(document, ['mouseup', 'touchcancel', 'touchend'], this._onTapStop);
                 return;
             }
 
-            on(document, ['mousemove', 'touchmove'], this._onTapMove, {passive: false});
+            on(document, ['mousemove', 'touchmove'], this._onTapMove, { passive: false });
 
             // Make area element visible
             css(this._area, 'display', 'block');
@@ -307,7 +333,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             if (this._scrollAvailable) {
 
                 // Detect mouse scrolling
-                on(this._targetElement, 'wheel', this._manualScroll, {passive: false});
+                on(this._targetElement, 'wheel', this._manualScroll, { passive: false });
 
                 /**
                  * The selection-area will also cover other element which are
@@ -328,7 +354,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _setupSelectionArea(): void {
-        const {_clippingElement, _targetElement, _area} = this;
+        const { _clippingElement, _targetElement, _area } = this;
         const tr = this._targetRect = _targetElement!.getBoundingClientRect();
 
         if (this._scrollAvailable) {
@@ -372,9 +398,9 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _onTapMove(evt: MouseEvent | TouchEvent): void {
-        const {x, y} = simplifyEvent(evt);
-        const {_scrollSpeed, _areaLocation, _options, _frame} = this;
-        const {speedDivider} = _options.behaviour.scrolling;
+        const { x, y } = simplifyEvent(evt);
+        const { _scrollSpeed, _areaLocation, _options, _frame } = this;
+        const { speedDivider } = _options.behaviour.scrolling;
         const _targetElement = this._targetElement as Element;
 
         _areaLocation.x2 = x;
@@ -392,7 +418,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
                 }
 
                 // Reduce velocity, use ceil in both directions to scroll at least 1px per frame
-                const {scrollTop, scrollLeft} = _targetElement;
+                const { scrollTop, scrollLeft } = _targetElement;
 
                 if (_scrollSpeed.y) {
                     _targetElement.scrollTop += ceil(_scrollSpeed.y / speedDivider);
@@ -430,7 +456,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _handleMoveEvent(evt: MouseEvent | TouchEvent) {
-        const {features} = this._options;
+        const { features } = this._options;
 
         /**
          * - Prevent auto-refresh for when pulling down on touch devices.
@@ -442,8 +468,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _onScroll(): void {
-        const {_scrollDelta, _options: {document}} = this;
-        const {scrollTop, scrollLeft} = document.scrollingElement ?? document.body;
+        const { _scrollDelta, _options: { document } } = this;
+        const { scrollTop, scrollLeft } = document.scrollingElement ?? document.body;
 
         // Adjust area start location
         this._areaLocation.x1 += _scrollDelta.x - scrollLeft;
@@ -457,7 +483,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _manualScroll(evt: ScrollEvent): void {
-        const {manualSpeed} = this._options.behaviour.scrolling;
+        const { manualSpeed } = this._options.behaviour.scrolling;
 
         // Consistent scrolling speed on all browsers
         const deltaY = evt.deltaY ? (evt.deltaY > 0 ? 1 : -1) : 0;
@@ -471,14 +497,21 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _recalculateSelectionAreaRect(): void {
-        const {_scrollSpeed, _areaLocation, _areaRect, _targetElement, _options} = this;
-        const {scrollTop, scrollHeight, clientHeight, scrollLeft, scrollWidth, clientWidth} = _targetElement as Element;
+        const { _scrollSpeed, _areaLocation, _areaRect, _targetElement, _options } = this;
+        const {
+            scrollTop,
+            scrollHeight,
+            clientHeight,
+            scrollLeft,
+            scrollWidth,
+            clientWidth
+        } = _targetElement as Element;
         const _targetRect = this._targetRect as DOMRect;
 
-        const {x1, y1} = _areaLocation;
-        let {x2, y2} = _areaLocation;
+        const { x1, y1 } = _areaLocation;
+        let { x2, y2 } = _areaLocation;
 
-        const {behaviour: {scrolling: {startScrollMargins}}} = _options;
+        const { behaviour: { scrolling: { startScrollMargins } } } = _options;
 
         if (x2 < _targetRect.left + startScrollMargins.x) {
             _scrollSpeed.x = scrollLeft ? -abs(_targetRect.left - x2 + startScrollMargins.x) : 0;
@@ -512,8 +545,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _redrawSelectionArea(): void {
-        const {x, y, width, height} = this._areaRect;
-        const {style} = this._area;
+        const { x, y, width, height } = this._areaRect;
+        const { style } = this._area;
 
         // Using transform will make the area's borders look blurry
         style.left = `${x}px`;
@@ -523,8 +556,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _onTapStop(evt: MouseEvent | TouchEvent | null, silent: boolean): void {
-        const {document, features} = this._options;
-        const {_singleClick} = this;
+        const { document, features } = this._options;
+        const { _singleClick } = this;
 
         // Remove event handlers
         off(document, ['mousemove', 'touchmove'], this._delayedTapMove);
@@ -546,7 +579,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         this._scrollSpeed.y = 0;
 
         // Unbind mouse scrolling listener
-        off(this._targetElement, 'wheel', this._manualScroll, {passive: true});
+        off(this._targetElement, 'wheel', this._manualScroll, { passive: true });
 
         // Remove selection-area from dom
         this._clippingElement.remove();
@@ -559,9 +592,9 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _updateElementSelection(): void {
-        const {_selectables, _options, _selection, _areaRect} = this;
-        const {stored, selected, touched} = _selection;
-        const {intersect, overlap} = _options.behaviour;
+        const { _selectables, _options, _selection, _areaRect } = this;
+        const { stored, selected, touched } = _selection;
+        const { intersect, overlap } = _options.behaviour;
 
         const invert = overlap === 'invert';
         const newlyTouched: Element[] = [];
@@ -614,7 +647,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         }
 
         _selection.selected = newlyTouched;
-        _selection.changed = {added, removed};
+        _selection.changed = { added, removed };
 
         // Prevent range selection when selection an area.
         this._latestElement = undefined;
@@ -629,8 +662,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _keepSelection(): void {
-        const {_options, _selection} = this;
-        const {selected, changed, touched, stored} = _selection;
+        const { _options, _selection } = this;
+        const { selected, changed, touched, stored } = _selection;
         const addedElements = selected.filter(el => !stored.includes(el));
 
         switch (_options.behaviour.overlap) {
@@ -681,7 +714,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
      * @param quiet If move / stop events should be fired
      */
     clearSelection(includeStored = true, quiet = false): void {
-        const {selected, stored, changed} = this._selection;
+        const { selected, stored, changed } = this._selection;
 
         changed.added = [];
         changed.removed.push(
@@ -700,7 +733,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             stored: includeStored ? [] : stored,
             selected: [],
             touched: [],
-            changed: {added: [], removed: []}
+            changed: { added: [], removed: [] }
         };
     }
 
@@ -746,7 +779,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
      * @param quiet - If this should not trigger the move event
      */
     select(query: SelectAllSelectors, quiet = false): Element[] {
-        const {changed, selected, stored} = this._selection;
+        const { changed, selected, stored } = this._selection;
         const elements = selectAll(query, this._options.document).filter(el =>
             !selected.includes(el) &&
             !stored.includes(el)
@@ -776,7 +809,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
      * @param quiet - If this should not trigger the move event
      */
     deselect(query: SelectAllSelectors, quiet = false) {
-        const {selected, stored, changed} = this._selection;
+        const { selected, stored, changed } = this._selection;
 
         const elements = selectAll(query, this._options.document).filter(el =>
             selected.includes(el) ||

--- a/packages/vanilla/src/types.ts
+++ b/packages/vanilla/src/types.ts
@@ -1,5 +1,5 @@
 import type SelectionArea from './index';
-import type {Intersection} from './utils';
+import type { Intersection } from './utils';
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export type DeepPartial<T> =
@@ -58,13 +58,19 @@ export type OverlapMode = 'keep' | 'drop' | 'invert';
 export interface Scrolling {
     speedDivider: number;
     manualSpeed: number;
-    startScrollMargins: {x: number, y: number};
+    startScrollMargins: { x: number, y: number };
 }
 
 export interface SingleTap {
     allow: boolean;
     intersect: TapMode;
 }
+
+export type MouseButton = 0 // Main
+                        | 1 // Auxiliary 
+                        | 2 // Secondary
+                        | 3 // Fourth
+                        | 4 // Fifth
 
 export interface Features {
     singleTap: SingleTap;
@@ -77,6 +83,7 @@ export interface Behaviour {
     startThreshold: number | Coordinates;
     overlap: OverlapMode;
     scrolling: Scrolling;
+    ignoredButtons: MouseButton[]
 }
 
 export interface SelectionOptions {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@viselect/vue",
-    "version": "3.4.0",
+    "version": "3.4.1",
     "description": "Simple, lightweight and modern library library for making visual DOM Selections.",
     "author": "Simon Reinisch <contact@reinisch.io>",
     "bugs": "https://github.com/Simonwep/selection/issues",


### PR DESCRIPTION
This PR adds an option `ignoredButtons` to `options.behavior` that is by default empty - i.e. no buttons are ignored.
The user of the library may then supply a collection of MouseButtons (integers 0 through 4) for which the selection-start should not be triggered. 

#212 