### PR TITLE
fix: Events not being triggered on last element deselection

### DIFF
--- a/packages/vanilla/src/index.ts
+++ b/packages/vanilla/src/index.ts
@@ -833,10 +833,6 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             stored.includes(el)
         );
 
-        if (!elements.length) {
-            return;
-        }
-
         this._selection.stored = stored.filter(el => !elements.includes(el));
         this._selection.selected = selected.filter(el => !elements.includes(el));
         this._selection.changed.added = [];


### PR DESCRIPTION
Fixes #238 

This PR removes an `if` statement that blocked `move` and `stop` events from being triggered because there were no more selected elements. 

## Steps to reproduce:

1. select elements by clicking or dragging a selection
2. unselect and leave only 1 element
3. click on that last element

Check the `stop` event containing no `stored` elements isn't triggered. 


